### PR TITLE
Update Temperature Unit to Fahrenheit

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Navigate to http://localhost:3000/locations to use the app.
 - **Limited Styling**: The app currently lacks CSS styling.
 - **No Tests**: Automated tests are not yet implemented.
 - **Limited CRUD Functionality**: Users can create and read locations, but cannot yet to update or delete locations.
-- **Metric Only**: Data is displayed with metric units; A toggle to switch to US customary units would be a user friendly addition.
+- **Units**: Temperature is displayed in Fahrenheit while other data is displayed with metric units; A toggle to switch between US customary units and metric units would be a user friendly addition.
 - **Failing Linting Tests**
 - **Accessible Design**
 - **Chart Limitations**: Temperature chart cannot display negative temperatures.

--- a/app/services/forecast_service.rb
+++ b/app/services/forecast_service.rb
@@ -19,7 +19,8 @@ class ForecastService
       longitude: longitude,
       daily: "temperature_2m_max,temperature_2m_min,precipitation_sum,wind_speed_10m_max,sunrise,sunset",
       timezone: "auto",
-      forecast_days: 7
+      forecast_days: 7,
+      temperature_unit: "fahrenheit"
     }
 
     begin

--- a/app/views/locations/forecast.html.erb
+++ b/app/views/locations/forecast.html.erb
@@ -4,8 +4,8 @@
   <thead>
     <tr>
       <th>Date</th>
-      <th>High Temperature (°C)</th>
-      <th>Low Temperature (°C)</th>
+      <th>High Temperature (°F)</th>
+      <th>Low Temperature (°F)</th>
       <th>Precipitation (mm)</th>
       <th>Max Wind Speed (km/hr)</th>
       <th>Sunrise</th>


### PR DESCRIPTION
Specify Fahrenheit in API call and update view.

Temperature is now displayed in Fahrenheit while other data is displayed with metric units; A toggle to switch between US customary units and metric units would be a user friendly addition.